### PR TITLE
Add support for GatesGarth

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "pocketbeagle"
 BBFILE_PATTERN_pocketbeagle = "^${LAYERDIR}/"
 BBFILE_PRIORITY_pocketbeagle = "5"
 
-LAYERSERIES_COMPAT_pocketbeagle = "dunfell"
+LAYERSERIES_COMPAT_pocketbeagle = "gatesgarth"

--- a/conf/machine/pocketbeagle.conf
+++ b/conf/machine/pocketbeagle.conf
@@ -20,13 +20,14 @@ WKS_FILE ?= "beaglebone-yocto.wks"
 IMAGE_INSTALL_append = " kernel-devicetree kernel-image-zimage"
 do_image_wic[depends] += "mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot"
 
-SERIAL_CONSOLES = "115200;ttyO0"
+SERIAL_CONSOLES ?= "115200;ttyS0 115200;ttyO0"
+SERIAL_CONSOLES_CHECK = "${SERIAL_CONSOLES}"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
-PREFERRED_VERSION_linux-yocto ?= "4.19%"
+PREFERRED_VERSION_linux-yocto ?= "5.4%"
 
 KERNEL_IMAGETYPE = "zImage"
-KERNEL_DEVICETREE = "am335x-pocketbeagle.dtb" 
+KERNEL_DEVICETREE = "am335x-pocketbeagle.dtb"
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
 SPL_BINARY = "MLO"

--- a/recipes-extended/linuxconsoletools/linuxconsoletools_1.6.0.bb
+++ b/recipes-extended/linuxconsoletools/linuxconsoletools_1.6.0.bb
@@ -38,7 +38,7 @@ do_install () {
     install -m 0644 ${S}/utils/extract ${D}${datadir}/joystick/
     install -m 0644 ${S}/utils/filter ${D}${datadir}/joystick/
     install -m 0644 ${S}/utils/ident ${D}${datadir}/joystick/
-    
+
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0755 ${S}/utils/js-set-enum-leds ${D}${sysconfdir}/udev/
     install -m 0644 ${S}/utils/80-stelladaptor-joystick.rules ${D}${sysconfdir}/udev/rules.d/

--- a/recipes-kernel/linux/linux-yocto_5.4.bbappend
+++ b/recipes-kernel/linux/linux-yocto_5.4.bbappend
@@ -1,14 +1,14 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-KBRANCH_pocketbeagle = "v4.19/standard/beaglebone"
+KBRANCH_pocketbeagle = "v5.4/standard/beaglebone"
 
 KMACHINE_pocketbeagle ?= "beaglebone"
 
-SRCREV_machine_pocketbeagle ?= "f0c6c85e155632580bd44a5db01cbb19dcc1559c"
+SRCREV_machine_pocketbeagle ?= "706efec4c1e270ec5dda92275898cd465dfdc7dd"
 
 COMPATIBLE_MACHINE_pocketbeagle = "pocketbeagle"
 
-LINUX_VERSION_pocketbeagle = "4.19.44"
+LINUX_VERSION_pocketbeagle = "5.4.58"
 
 SRC_URI += "file://defconfig"
 SRC_URI += "file://0001-pocketbeagle-add-e-ale-paddle-device-and-gpio-pinmux.patch"


### PR DESCRIPTION
Note: I am very new to Yocto.

I have a pocketbeagle (not the e-ale version, though), and I use `e-ale/meta-pocketbeagle` as a BSP. Because I am running on GatesGarth, it was not working. This PR is adding support for GatesGarth.

To test it, I built a minimal image with my changes and ran it on my pocketbeagle. I can login, so I'm assuming that it works (but maybe that's not enough :see_no_evil:). Also, I have no clue if this breaks support for Dunfell or not :confused:.

Resolves #4.